### PR TITLE
Docs: update `ex_doc` settings and installation docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ end
 
 ## Installation
 
-If [available in Hex](https://hex.pm/docs/publish), the package can be installed by adding `gen_lsp` to your list of dependencies in `mix.exs`:
+This package can be installed by adding `gen_lsp` to your list of dependencies in `mix.exs`:
 
 ```elixir
 def deps do
@@ -222,5 +222,4 @@ def deps do
   ]
 end
 ```
-
-Documentation can be generated with [ExDoc](https://github.com/elixir-lang/ex_doc) and published on [HexDocs](https://hexdocs.pm). Once published, the docs can be found at <https://hexdocs.pm/gen_lsp>.
+Documentation can be found at <https://hexdocs.pm/gen_lsp>.

--- a/mix.exs
+++ b/mix.exs
@@ -1,10 +1,13 @@
 defmodule GenLSP.MixProject do
   use Mix.Project
 
+  @source_url "https://github.com/mhanberg/gen_lsp"
+
   def project do
     [
       app: :gen_lsp,
       description: "Library for creating language servers",
+      source_url: @source_url,
       version: "0.0.10",
       elixir: "~> 1.10",
       start_permanent: Mix.env() == :prod,
@@ -43,6 +46,7 @@ defmodule GenLSP.MixProject do
 
   defp docs() do
     [
+      main: "GenLSP",
       nest_modules_by_prefix: [
         "GenLSP.Requests",
         "GenLSP.Notifications",
@@ -57,7 +61,7 @@ defmodule GenLSP.MixProject do
     [
       maintainers: ["Mitchell Hanberg"],
       licenses: ["MIT"],
-      links: %{github: "https://github.com/mhanberg/gen_lsp"},
+      links: %{GitHub: @source_url},
       files: ~w(lib LICENSE mix.exs README.md .formatter.exs)
     ]
   end


### PR DESCRIPTION
Thanks for your work on this package! I'm going to be giving it a go fairly soon to integrate a library I'm working on with VSCode.

While browsing, I noticed a couple small documentation-related things that I've updated in this PR:

- Changes to `docs/0` in `mix.exs`:
  - Added a `:source_url` - this allows the generated docs to link to source
  - Added a `:main` - this allows https://hexdocs.pm/gen_lsp to redirect to the `GenLSP` module doc instead of the API reference. In my opinion, the `GenLSP` module doc is a much more useful starting-off point when viewing the docs.
- Updated "Installation" section of the README to reflect that this package has indeed been published. 🙂 